### PR TITLE
solve SecureRandom problem

### DIFF
--- a/8.5/jre8/Dockerfile
+++ b/8.5/jre8/Dockerfile
@@ -1,5 +1,6 @@
 FROM openjdk:8-jre
 
+ENV JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
 RUN mkdir -p "$CATALINA_HOME"


### PR DESCRIPTION
Add ENV JAVA_OPTS="$JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
To solve the problem :
WARNING [localhost-startStop-1] org.apache.catalina.util.SessionIdGeneratorBase.createSecureRandom Creation of SecureRandom instance for session ID generation using [SHA1PRNG] took [1,218] milliseconds.